### PR TITLE
Improved Upgrade Script

### DIFF
--- a/overlay_minimal/usr/bin/upgrade_openmiko.sh
+++ b/overlay_minimal/usr/bin/upgrade_openmiko.sh
@@ -1,7 +1,41 @@
 #!/bin/bash
 
-# exit when any command fails
-set -e
+function do_flash {
+	# $1 = path to file (/tmp/rootfs.jffs2)
+	# $2 = MTD device number (0, 1, 2)
+	if [[ ! -n $1 || ! -n $2 ]]; then
+		echo "Invalid parameters given to do_flash."
+		return 1
+	fi
+	
+	FILE=$1
+	DEVICE=/dev/mtd${2}
+	BLOCKDEVICE=/dev/mtdblock${2}
+	if [[ ! -s $FILE ]]; then
+		echo "ERROR: File $FILE does not exist or is 0 bytes."
+		return 1
+	fi
+	
+	FILE_SIZE=$(wc -c < $FILE)
+	echo "Flashing contents of $(basename $FILE) to $DEVICE..."
+	flash_eraseall $DEVICE
+	dd if=$FILE of=$BLOCKDEVICE
+	if [[ $? -ne 0 ]]; then
+		echo "ERROR: Failed to flash device $DEVICE from file $(basename $FILE)."
+		return 1
+	fi
+	echo "Wrote $(basename $FILE) to $DEVICE."
+	
+	# Read back flash contents and checksum
+	echo "Comparing contents of $DEVICE to $(basename $FILE)... this may take a while"
+	dd if=$BLOCKDEVICE conv=sync,noerror bs=1 count=$FILE_SIZE 2>/dev/null | cmp $FILE
+	if [[ $? -ne 0 ]]; then
+		echo "ERROR: New flash contents on $DEVICE do not match the source file $FILE."
+		return 1
+	else
+		echo "Verified the contents of $DEVICE match the source file $FILE."
+	fi
+}
 
 if [[ $# -eq 0 ]] ; then
     echo './upgrade_openmiko.sh <GIT_TAG>'
@@ -19,24 +53,50 @@ fi
 
 GIT_TAG="$1"
 
+echo -e "\nStopping services..."
 killall mjpg_streamer || echo "Process was not running."
 killall autonight || echo "Process was not running."
 killall videocapture || echo "Process was not running."
 killall v4l2rtspserver || echo "Process was not running."
+echo "Services stopped."
 
 cd /tmp
 
-curl -L https://github.com/openmiko/openmiko/releases/download/$GIT_TAG/rootfs.jffs2 -o /tmp/rootfs.jffs2
-curl -L https://github.com/openmiko/openmiko/releases/download/$GIT_TAG/uImage.lzma -o /tmp/uImage.lzma
+echo -e "\nDownloading updated images from GitHub..."
+curl -fL https://github.com/openmiko/openmiko/releases/download/$GIT_TAG/rootfs.jffs2 -o /tmp/rootfs.jffs2
+if [[ $? -ne 0 ]]; then
+	echo "Failed to download OpenMiko $GIT_TAG rootfs.jffs2 from GitHub."
+	exit 1
+fi
 
-echo "Flashing root file system (rootfs)"
-flash_eraseall /dev/mtd2
-dd if=/tmp/rootfs.jffs2 of=/dev/mtdblock2
-echo "Wrote rootfs.jffs2"
+curl -fL https://github.com/openmiko/openmiko/releases/download/$GIT_TAG/uImage.lzma -o /tmp/uImage.lzma
+if [[ $? -ne 0 ]]; then
+	echo "Failed to download OpenMiko $GIT_TAG uImage.lzma from GitHub."
+	exit 1
+fi
+echo "Images downloaded successfully."
 
-echo "Flashing kernel image"
-flash_eraseall /dev/mtd1
-dd if=/tmp/uImage.lzma of=/dev/mtdblock1
-echo "Wrote uImage.lzma"
+# Doing a while loop here to use break in case of failure
+while true; do
+	echo -e "\nFlashing root file system (rootfs)"
+	# Flash rootfs.jffs2 to /dev/mtd2
+	if do_flash /tmp/rootfs.jffs2 2; then
+		true
+	else
+		break
+	fi
 
-echo "Image flashed. Reboot is required."
+	echo -e "\nFlashing kernel image (uImage.lzma)"
+	# Flash uImage.lzma to /dev/mtd1
+	if do_flash /tmp/uImage.lzma 1; then
+		true
+	else
+		break
+	fi
+	
+	echo -e "\nOpenMiko image flashed successfully. Reboot is required.\n"
+	exit 0
+done
+
+echo -e "\nERROR: Upgrade failed.  Your system may not survive a reboot!  Troubleshoot and retry the upgrade.\n"
+exit 1


### PR DESCRIPTION
I made several modifications to the upgrade_openmiko.sh script for better logging and upgrade safety.

**Enhancements**
1. Fixed curl statements to fail on 400+ HTTP response codes.  When providing an incorrect release tag, curl would still succeed and the flash would be erased and overwritten with invalid contents.  Now curl will report a nonzero exit code and the script will terminate without affecting flash.
2. Improved logging output at each step in the upgrade process so users will be able to diagnose failures.
3. Added verification steps using `cmp`  to compare new flash contents to each source file.

**Test Output**
```
Are you sure you want to flash new firmware? y

Downloading updated images from GitHub...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   620  100   620    0     0   1067      0 --:--:-- --:--:-- --:--:--  1731
100 8683k  100 8683k    0     0  2333k      0  0:00:03  0:00:03 --:--:-- 3372k
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   619  100   619    0     0   1736      0 --:--:-- --:--:-- --:--:--  1799
100 2045k  100 2045k    0     0  1722k      0  0:00:01  0:00:01 --:--:-- 3594k
Images downloaded successfully.

Flashing root file system (rootfs)
Flashing contents of rootfs.jffs2 to /dev/mtd2...
Erasing 32 Kibyte @ d30000 - 100% complete.
17366+1 records in
17366+1 records out
Wrote rootfs.jffs2 to /dev/mtd2.
Comparing contents of /dev/mtd2 to rootfs.jffs2... this may take a while
Verified the contents of /dev/mtd2 match the source file /tmp/rootfs.jffs2.

Flashing kernel image (uImage.lzma)
Flashing contents of uImage.lzma to /dev/mtd1...
Erasing 32 Kibyte @ 200000 - 100% complete.
4091+1 records in
4091+1 records out
Wrote uImage.lzma to /dev/mtd1.
Comparing contents of /dev/mtd1 to uImage.lzma... this may take a while
Verified the contents of /dev/mtd1 match the source file /tmp/uImage.lzma.

OpenMiko image flashed successfully. Reboot is required.

```