### PR TITLE
Add modules

### DIFF
--- a/doc/modules.md
+++ b/doc/modules.md
@@ -1,0 +1,42 @@
+# Modules
+
+Due to space limitations on the cameras we created a module system that allows you to choose the extra functionality that you would like to add to your devices.This approach also makes it easier for developers to contribute to the project without needing to create pull requests back to the main repositiory.
+
+## Module compatibilty
+
+The module system has no built-in approach to ensuring modules are compatible with updates to the core system. It is each developer's responsibility to test and document the compatibility of their modules.
+
+## Module list
+
+| Name | Description |
+| --- | --- | --- |
+| [ddns](https://github.com/martinbutt/openmiko-module-ddns) | Adds ddclient for dynamic DNS |
+| [fsck.vfat](https://github.com/martinbutt/openmiko-module-fsck-vfat) | Adds fsck.vfat for checking FAT partitions on the SD card |
+| [fsck.ext](https://github.com/martinbutt/openmiko-module-fsck-ext) | Adds e2fsck for checking ext2/3/4 partitions on the SD card |
+
+## Installing modules
+
+To install a module, add the `.tar.xz` to the modules folder of the SD card. It will be installed when the camera starts up.
+
+## Uninstalling modules
+
+To uninstall a module, SSH onto the device and `cd /etc/openmiko.d/modules`. Here you will find all uninstall scripts for the modules. `cd` into the module folder and run `uninstall.sh`.
+
+## Creating modules
+
+Modules a contained in `.tar.xz` files. Inside you will find a files structure:
+```
+overlay/ (optional)
+pre-install.sh (optional)
+post-install.sh (optional)
+uninstall.sh
+```
+
+Inside the `overlay/` folder you can place files that need to be installed onto the file system into their respective locations, e.g.
+```
+overlay/usr/bin/fsck.vfat
+```
+
+If you want a script to run before or after the files have been copied, then you can add `pre-install.sh` or `post-install.sh`.
+
+You must include an `uninstall.sh` to revert the changes.

--- a/doc/modules.md
+++ b/doc/modules.md
@@ -9,7 +9,7 @@ The module system has no built-in approach to ensuring modules are compatible wi
 ## Module list
 
 | Name | Description |
-| --- | --- | --- |
+| --- | --- |
 | [ddns](https://github.com/martinbutt/openmiko-module-ddns) | Adds ddclient for dynamic DNS |
 | [fsck.vfat](https://github.com/martinbutt/openmiko-module-fsck-vfat) | Adds fsck.vfat for checking FAT partitions on the SD card |
 | [fsck.ext](https://github.com/martinbutt/openmiko-module-fsck-ext) | Adds e2fsck for checking ext2/3/4 partitions on the SD card |

--- a/overlay_minimal/usr/bin/general_init.sh
+++ b/overlay_minimal/usr/bin/general_init.sh
@@ -86,6 +86,10 @@ clear_config_partition() {
 }
 clear_config_partition
 
+if [ -d "/sdcard/modules" ]
+then
+	. /usr/bin/install-modules.sh
+fi
 
 # Should implement an optimization here to check for each file
 # so we don't wear out flash chip

--- a/overlay_minimal/usr/bin/install-modules.sh
+++ b/overlay_minimal/usr/bin/install-modules.sh
@@ -21,9 +21,10 @@ then
 			pushd "$MODULE_NAME"
 			xz -d < "$MODULE" | tar x
 
-			if [ -x "preinstall.sh" ]; then
-				./preinstall.sh
-				rm -f preinstall.sh
+			if [ -f "pre-install.sh" ]; then
+				chmod 755 pre-install.sh
+				./pre-install.sh
+				rm -f pre-install.sh
 			fi
 
 			if [ -d "overlay" ]; then
@@ -31,14 +32,15 @@ then
 				rm -rf overlay
 			fi
 
-			if [ -x "postinstall.sh" ]; then
-				./postinstall.sh
-				rm -f postinstall.sh
+			if [ -f "post-install.sh" ]; then
+				chmod 755 post-install.sh
+				./post-install.sh
+				rm -f post-install.sh
 			fi
 
 			popd
 
-			rm -f "/etc/openmiko.d/modules/$MODULE/$MODULE_NAME.tar.xz"
+			rm -f "/etc/openmiko.d/modules/$MODULE_NAME/$MODULE_NAME.tar.xz"
 		fi
 	done
 

--- a/overlay_minimal/usr/bin/install-modules.sh
+++ b/overlay_minimal/usr/bin/install-modules.sh
@@ -15,13 +15,15 @@ then
 		if [ -f "$MODULE" ]; then
 			MODULE_NAME=`basename $MODULE .tar.xz`
 			logger -s -t general_init "Installing module $MODULE_NAME"
-			cp "$MODULE" /etc/openmiko.d/modules/
-			xz -d < "$MODULE" | tar x
-			pushd "$MODULE_NAME"
 
-			if [ -x "pre-install.sh" ]; then
-				./pre-install.sh
-				rm -f pre-install.sh
+			mkdir -p /etc/openmiko.d/modules/$MODULE_NAME
+			cp "$MODULE" /etc/openmiko.d/modules/$MODULE_NAME
+			pushd "$MODULE_NAME"
+			xz -d < "$MODULE" | tar x
+
+			if [ -x "preinstall.sh" ]; then
+				./preinstall.sh
+				rm -f preinstall.sh
 			fi
 
 			if [ -d "overlay" ]; then
@@ -29,14 +31,14 @@ then
 				rm -rf overlay
 			fi
 
-			if [ -x "post-install.sh" ]; then
-				./post-install.sh
-				rm -f post-install.sh
+			if [ -x "postinstall.sh" ]; then
+				./postinstall.sh
+				rm -f postinstall.sh
 			fi
 
 			popd
 
-			rm -f "/etc/openmiko.d/modules/$MODULE_NAME.tar.xz"
+			rm -f "/etc/openmiko.d/modules/$MODULE/$MODULE_NAME.tar.xz"
 		fi
 	done
 

--- a/overlay_minimal/usr/bin/install-modules.sh
+++ b/overlay_minimal/usr/bin/install-modules.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -x
+
+if [ -d "/sdcard/modules" ]
+then
+	logger -s -t general_init "Installing modules from sdcard"
+
+	if [ ! -d "/etc/openmiko.d/modules" ]; then
+		mkdir -p /etc/openmiko.d/modules
+	fi
+
+	pushd /etc/openmiko.d/modules/
+
+	for MODULE in /sdcard/modules/*.tar.xz; do
+		if [ -f "$MODULE" ]; then
+			MODULE_NAME=`basename $MODULE .tar.xz`
+			logger -s -t general_init "Installing module $MODULE_NAME"
+			cp "$MODULE" /etc/openmiko.d/modules/
+			xz -d < "$MODULE" | tar x
+			pushd "$MODULE_NAME"
+
+			if [ -x "pre-install.sh" ]; then
+				./pre-install.sh
+				rm -f pre-install.sh
+			fi
+
+			if [ -d "overlay" ]; then
+				find overlay -type f -exec sh -c 'SOURCE={};TARGET=${SOURCE#overlay};install -D $SOURCE $TARGET' \; -print
+				rm -rf overlay
+			fi
+
+			if [ -x "post-install.sh" ]; then
+				./post-install.sh
+				rm -f post-install.sh
+			fi
+
+			popd
+
+			rm -f "/etc/openmiko.d/modules/$MODULE_NAME.tar.xz"
+		fi
+	done
+
+	popd
+fi
+


### PR DESCRIPTION
First of all, huge shout out to @tachang for this project! Getting Buildroot running and the development docker image made this very easy!

I was working on adding fsck and dynamic dns, when I ran into issues with the size of the `demo.bin` getting too large, e.g.

`Error: rootfs image must be less than 8978432. It is 9262908.`

I assume this is a limitation of the flashing method. I looked through the packages and it looks like everything else non-essential has been stripped out already (except maybe some lighthttp modules, but I didn't have enough context to know if I could remove any of them).

It seems like this space limitation will prevent major developments going forwards, so I have developed a module system that allows packaged modules to be overlaid outside of the rootfs. This will allow users to choose the modules that fit their needs to use in the limited space.

See: https://github.com/martinbutt/openmiko/tree/add-modules for the code changes and https://github.com/martinbutt/openmiko/blob/add-modules/doc/modules.md for the documentation.

I have created several modules already:
https://github.com/martinbutt/openmiko-module-fsck-vfat
https://github.com/martinbutt/openmiko-module-fsck-ext
https://github.com/martinbutt/openmiko-module-ddns

The the `tar.xz` files can be downloaded from the releases page in each repo and added to the `modules/` folder on the SD card. It will be copied to the camera on boot.

Note that the fsck modules require this to be merged into the core first:
https://github.com/openmiko/openmiko/pull/81


