### PR TITLE
Remove need for API to use nightmode

### DIFF
--- a/overlay_minimal/etc/init.d/S75autonight
+++ b/overlay_minimal/etc/init.d/S75autonight
@@ -14,6 +14,16 @@ case "$1" in
 		exit 0
 	fi
 	logger -s -t autonight "Starting autonight"
+
+	. /usr/bin/libgpio.sh
+	gpio_select_gpiochip 0
+
+	for pin in 38 39 49; do
+		gpio_export $pin
+		gpio_direction_output $pin
+		gpio_set_active_low $pin 0
+	done
+
 	if [ -z "$AUTONIGHT_PARAMS" ]; then
 		AUTONIGHT_PARAMS="-j 3 -w 3 -1 1200000 -2 930000,14,10 -3 3000,17,8"
 	fi

--- a/overlay_minimal/usr/bin/nightmode.sh
+++ b/overlay_minimal/usr/bin/nightmode.sh
@@ -2,17 +2,19 @@
 
 NIGHTVISION_FILE="/tmp/night_vision_enabled"
 
+. /scripts/common_functions.sh
+
 case $1 in
   on)
     echo "$(date) - nightmode on"
-    curl -d value=0 http://127.0.0.1:8081/api/ir_cut 2>/dev/null
-    curl -d value=1 http://127.0.0.1:8081/api/ir_led 2>/dev/null
+    ir_cut off
+    ir_led off
     echo "1" > $NIGHTVISION_FILE
     ;;
   off)
     echo "$(date) - nightmode off"
-    curl -d value=1 http://127.0.0.1:8081/api/ir_cut 2>/dev/null
-    curl -d value=0 http://127.0.0.1:8081/api/ir_led 2>/dev/null
+    ir_led on
+    ir_cut on
     echo "0" > $NIGHTVISION_FILE
     ;;
   *)


### PR DESCRIPTION
Currently `/usr/bin/nightmode.sh` requires access to the API to toggle the LEDs. This PR toggles them without the use of the API. I have used functions from `/scripts/common_functions.sh`. I'm not sure if I should rely on those, or refactor out the parts I need into a separate file. It looks like the file was taken from an old version of Dafang Hacks and mostly won't work with Openmiko. Let me know if you want me to remove those old parts and clean it up.