### PR TITLE
IR LED fix

### DIFF
--- a/overlay_minimal/etc/init.d/S60camera
+++ b/overlay_minimal/etc/init.d/S60camera
@@ -69,7 +69,7 @@ start_camera() {
 
 
 	# Only set the number of v4l2loopback devices that we need. This hopefully will save some memory.
-	DEVICE_COUNT=1 # Default to 1, not sure if this can be 0 or 1.
+	DEVICE_COUNT=0
 	if [ ! -z "$VIDEO_DEV_1" ]; then
 		DEVICE_COUNT="$((DEVICE_COUNT + 1))"
 	fi

--- a/overlay_minimal/etc/openmiko.conf
+++ b/overlay_minimal/etc/openmiko.conf
@@ -25,6 +25,9 @@ MJPEG_FPS=15
 ENABLE_AUTONIGHT=1
 AUTONIGHT_PARAMS="-j 3 -w 3 -1 1200000 -2 930000,14,10 -3 3000,17,8"
 
+# Enables/Disables IR LEDs in night mode. Useful when you have want to use a different nightvision light than the onboard camera.
+DISABLE_IR_LEDS=0
+
 # Set alternate videocapture settings file
 # VIDEO_CAPTURE_SETTINGS=/etc/videocapture_settings_1_encoder.json
 

--- a/overlay_minimal/etc/profile
+++ b/overlay_minimal/etc/profile
@@ -1,0 +1,21 @@
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
+if [ "$PS1" ]; then
+    if [ "`id -u`" -eq 0 ]; then
+        export PS1='$(hostname):# '
+    else
+        export PS1='$(hostname):$ '
+    fi
+fi
+
+export PAGER='/bin/more '
+export EDITOR='/bin/vi'
+
+
+# Source configuration files from /etc/profile.d
+for i in /etc/profile.d/*.sh ; do
+    if [ -r "$i" ]; then
+        . $i
+    fi
+    unset i
+done

--- a/overlay_minimal/usr/bin/nightmode.sh
+++ b/overlay_minimal/usr/bin/nightmode.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 NIGHTVISION_FILE="/tmp/night_vision_enabled"
+DISABLE_IR_LEDS=0
 
 if [[ -f /etc/openmiko.conf ]]; then
 	. /etc/openmiko.conf
@@ -45,7 +46,7 @@ ir_cut() {
 case $1 in
 	on)
 		echo "$(date) - nightmode on"
-		if [ "$DISABLE_LEDS" == "0" ]; then
+		if [ "$DISABLE_IR_LEDS" == "0" ]; then
 			ir_led on
 			ir_cut off
 		fi

--- a/utilities/openmiko-gen.sh
+++ b/utilities/openmiko-gen.sh
@@ -49,7 +49,7 @@ while [[ ${DETAILS_CORRECT} != [yY] ]]; do
     echo ""
   done
 
-  echo "Enable LEDS"
+  echo "Enable LEDs (The orange/blue LEDs on the back of the camera)"
   echo "0) Disable"
   echo "1) Enable"
 
@@ -58,10 +58,20 @@ while [[ ${DETAILS_CORRECT} != [yY] ]]; do
     echo ""
   done
 
+  echo "Enable IR LEDs (for night vision)"
+  echo "0) Disable"
+  echo "1) Enable"
+
+  while [[ ${ENABLE_IR_LEDS} != [01] ]]; do
+    read -n1 -rp "Enter 0 or 1: " ENABLE_IR_LEDS
+    echo ""
+  done
+
   echo -e "\nCamera Type: "
   [ "${CAM_TYPE}" == "0" ] && echo -e "Wyze V2" || echo -e "Wyze V2 Pan or Dafang"
   echo "Enable MJPEG over HTTP: ${ENABLE_MJPEG_OVER_HTTP}"
-  echo "Enable LEDS: ${ENABLE_LEDS}"
+  echo "Enable LEDs: ${ENABLE_LEDS}"
+  echo "Enable IR LEDs: ${ENABLE_IR_LEDS}"
 
   read -n1 -rp "Is this correct? (y/n): " DETAILS_CORRECT
 done
@@ -87,6 +97,8 @@ MJPEG_FPS=15
 # Script that detects nighttime/daytime and turns on IR LEDs
 ENABLE_AUTONIGHT=1
 AUTONIGHT_PARAMS="-j 3 -w 3 -1 1200000 -2 930000,14,10 -3 3000,17,8"
+# Enables/Disables IR LEDs in night mode. Useful when you have want to use a different nightvision light than the onboard camera.
+DISABLE_IR_LEDS=$((ENABLE_IR_LEDS ^ 1))
 # Set alternate videocapture settings file
 # VIDEO_CAPTURE_SETTINGS=/etc/videocapture_settings_1_encoder.json
 # Set enable audio (is currently buggy, use at your own risk!)
@@ -97,7 +109,7 @@ VIDEO_DEV_2=/dev/video4
 VIDEO_DEV_3=/dev/video5
 # Use 8189fs for WyzeCam V2. For the WyzeCam Pan and Dafang use 8189es
 WIFI_MODULE=${WIFI_MODULE}
-# Disables LEDs on the camera
+# Disables LEDs on the camera (The orange/blue LEDs on the back of the camera)
 DISABLE_LEDS=$((ENABLE_LEDS ^ 1))
 # Enable Logging
 ENABLE_LOGGING=0


### PR DESCRIPTION
# New Features
* Added the `DISABLE_IR_LEDS` setting for enabling/disabling the IR LEDs separate from the orange/blue LEDs on the back of the camera (for disabling those LEDs, use `DISABLE_LEDS`).

# Bug Fixes
* Fix IR LEDs not turning on when `DISABLE_LEDS=1` in `openmiko.conf`