### PR TITLE
Update wpa-gen.sh

### DIFF
--- a/utilities/wpa-gen.sh
+++ b/utilities/wpa-gen.sh
@@ -61,7 +61,7 @@ bgscan="simple:30:-45:300"
 
 network={
         ssid="${WPA_SSID}"
-        scan_ssid="${SCAN_SSID}"
+        scan_ssid=${SCAN_SSID}
         key_mgmt=WPA-PSK
         pairwise=CCMP TKIP
         group=CCMP TKIP WEP104 WEP40


### PR DESCRIPTION
Quotes around the scan_ssid causes the following error:

Line 8: invalid number ""0""
Line 8: failed to parse scan_ssid '"0"'.

wpa-supplicant documentation doesn't say it should be enclosed in quotations, it states: scan_ssid
SSID scan technique; 0 (default) or 1. Technique 0 scans for the SSID using a broadcast Probe Request frame while 1 uses a directed Probe Request frame. Access points that cloak themselves by not broadcasting their SSID require technique 1, but beware that this scheme can cause scanning to take longer to complete. bssid

https://www.daemon-systems.org/man/wpa_supplicant.conf.5.html